### PR TITLE
feat: dev rex

### DIFF
--- a/include/REX/REX/INI.h
+++ b/include/REX/REX/INI.h
@@ -88,36 +88,13 @@ namespace REX::INI
 	using Str = Setting<std::string, Store>;
 }
 
-namespace REX::INI::Impl
+template <class T, class S, class CharT>
+struct std::formatter<REX::INI::Setting<T, S>, CharT> : std::formatter<T, CharT>
 {
-#	ifdef __cpp_lib_format
-	template <class T, class CharT>
-	struct formatter : std::formatter<T, CharT>
+	template <class FormatContext>
+	auto format(const REX::INI::Setting<T, S>& a_setting, FormatContext& a_ctx) const
 	{
-		template <class FormatContext>
-		auto format(REX::INI::Setting<T> a_setting, FormatContext& a_ctx) const
-		{
-			return std::formatter<T, CharT>::format(a_setting.GetValue(), a_ctx);
-		}
-	};
-#	endif
-}
-
-#	ifdef __cpp_lib_format
-namespace std
-{
-	// clang-format off
-	template <class CharT> struct formatter<REX::INI::Bool<>, CharT> : REX::INI::Impl::formatter<bool, CharT> {};
-	template <class CharT> struct formatter<REX::INI::F32<>, CharT> : REX::INI::Impl::formatter<float, CharT> {};
-	template <class CharT> struct formatter<REX::INI::F64<>, CharT> : REX::INI::Impl::formatter<double, CharT> {};
-	template <class CharT> struct formatter<REX::INI::I8<>, CharT> : REX::INI::Impl::formatter<std::int8_t, CharT> {};
-	template <class CharT> struct formatter<REX::INI::I16<>, CharT> : REX::INI::Impl::formatter<std::int16_t, CharT> {};
-	template <class CharT> struct formatter<REX::INI::I32<>, CharT> : REX::INI::Impl::formatter<std::int32_t, CharT> {};
-	template <class CharT> struct formatter<REX::INI::U8<>, CharT> : REX::INI::Impl::formatter<std::uint8_t, CharT> {};
-	template <class CharT> struct formatter<REX::INI::U16<>, CharT> : REX::INI::Impl::formatter<std::uint16_t, CharT> {};
-	template <class CharT> struct formatter<REX::INI::U32<>, CharT> : REX::INI::Impl::formatter<std::uint32_t, CharT> {};
-	template <class CharT> struct formatter<REX::INI::Str<>, CharT> : REX::INI::Impl::formatter<std::string, CharT> {};
-	// clang-format on
-}
-#	endif
+		return std::formatter<T, CharT>::format(a_setting.GetValue(), a_ctx);
+	}
+};
 #endif

--- a/include/REX/REX/JSON.h
+++ b/include/REX/REX/JSON.h
@@ -85,36 +85,13 @@ namespace REX::JSON
 	using Str = Setting<std::string, Store>;
 }
 
-namespace REX::JSON::Impl
+template <class T, class S, class CharT>
+struct std::formatter<REX::JSON::Setting<T, S>, CharT> : std::formatter<T, CharT>
 {
-#	ifdef __cpp_lib_format
-	template <class T, class CharT>
-	struct formatter : std::formatter<T, CharT>
+	template <class FormatContext>
+	auto format(const REX::JSON::Setting<T, S>& a_setting, FormatContext& a_ctx) const
 	{
-		template <class FormatContext>
-		auto format(REX::JSON::Setting<T> a_setting, FormatContext& a_ctx) const
-		{
-			return std::formatter<T, CharT>::format(a_setting.GetValue(), a_ctx);
-		}
-	};
-#	endif
-}
-
-#	ifdef __cpp_lib_format
-namespace std
-{
-	// clang-format off
-	template <class CharT> struct formatter<REX::JSON::Bool<>, CharT> : REX::JSON::Impl::formatter<bool, CharT> {};
-	template <class CharT> struct formatter<REX::JSON::F32<>, CharT> : REX::JSON::Impl::formatter<float, CharT> {};
-	template <class CharT> struct formatter<REX::JSON::F64<>, CharT> : REX::JSON::Impl::formatter<double, CharT> {};
-	template <class CharT> struct formatter<REX::JSON::I8<>, CharT> : REX::JSON::Impl::formatter<std::int8_t, CharT> {};
-	template <class CharT> struct formatter<REX::JSON::I16<>, CharT> : REX::JSON::Impl::formatter<std::int16_t, CharT> {};
-	template <class CharT> struct formatter<REX::JSON::I32<>, CharT> : REX::JSON::Impl::formatter<std::int32_t, CharT> {};
-	template <class CharT> struct formatter<REX::JSON::U8<>, CharT> : REX::JSON::Impl::formatter<std::uint8_t, CharT> {};
-	template <class CharT> struct formatter<REX::JSON::U16<>, CharT> : REX::JSON::Impl::formatter<std::uint16_t, CharT> {};
-	template <class CharT> struct formatter<REX::JSON::U32<>, CharT> : REX::JSON::Impl::formatter<std::uint32_t, CharT> {};
-	template <class CharT> struct formatter<REX::JSON::Str<>, CharT> : REX::JSON::Impl::formatter<std::string, CharT> {};
-	// clang-format on
-}
-#	endif
+		return std::formatter<T, CharT>::format(a_setting.GetValue(), a_ctx);
+	}
+};
 #endif

--- a/include/REX/REX/TOML.h
+++ b/include/REX/REX/TOML.h
@@ -104,36 +104,13 @@ namespace REX::TOML
 	using Str = Setting<std::string, Store>;
 }
 
-namespace REX::TOML::Impl
+template <class T, class S, class CharT>
+struct std::formatter<REX::TOML::Setting<T, S>, CharT> : std::formatter<T, CharT>
 {
-#	ifdef __cpp_lib_format
-	template <class T, class CharT>
-	struct formatter : std::formatter<T, CharT>
+	template <class FormatContext>
+	auto format(const REX::TOML::Setting<T, S>& a_setting, FormatContext& a_ctx) const
 	{
-		template <class FormatContext>
-		auto format(REX::TOML::Setting<T> a_setting, FormatContext& a_ctx) const
-		{
-			return std::formatter<T, CharT>::format(a_setting.GetValue(), a_ctx);
-		}
-	};
-#	endif
-}
-
-#	ifdef __cpp_lib_format
-namespace std
-{
-	// clang-format off
-	template <class CharT> struct formatter<REX::TOML::Bool<>, CharT> : REX::TOML::Impl::formatter<bool, CharT> {};
-	template <class CharT> struct formatter<REX::TOML::F32<>, CharT> : REX::TOML::Impl::formatter<float, CharT> {};
-	template <class CharT> struct formatter<REX::TOML::F64<>, CharT> : REX::TOML::Impl::formatter<double, CharT> {};
-	template <class CharT> struct formatter<REX::TOML::I8<>, CharT> : REX::TOML::Impl::formatter<std::int8_t, CharT> {};
-	template <class CharT> struct formatter<REX::TOML::I16<>, CharT> : REX::TOML::Impl::formatter<std::int16_t, CharT> {};
-	template <class CharT> struct formatter<REX::TOML::I32<>, CharT> : REX::TOML::Impl::formatter<std::int32_t, CharT> {};
-	template <class CharT> struct formatter<REX::TOML::U8<>, CharT> : REX::TOML::Impl::formatter<std::uint8_t, CharT> {};
-	template <class CharT> struct formatter<REX::TOML::U16<>, CharT> : REX::TOML::Impl::formatter<std::uint16_t, CharT> {};
-	template <class CharT> struct formatter<REX::TOML::U32<>, CharT> : REX::TOML::Impl::formatter<std::uint32_t, CharT> {};
-	template <class CharT> struct formatter<REX::TOML::Str<>, CharT> : REX::TOML::Impl::formatter<std::string, CharT> {};
-	// clang-format on
-}
-#	endif
+		return std::formatter<T, CharT>::format(a_setting.GetValue(), a_ctx);
+	}
+};
 #endif


### PR DESCRIPTION
- `std::formatter` is always going to exist at this point. Could also look into removing the other format ifdef's in the library.